### PR TITLE
Complete reworking of the state management in Player51

### DIFF
--- a/src/js/player51.js
+++ b/src/js/player51.js
@@ -495,7 +495,8 @@ Player51.prototype.prepareOverlay = function (rawjson) {
 
   // Format 1
   if (typeof(rawjson.objects) !== "undefined") {
-    this._prepareOverlay_auxFormat1Objects(rawjson.objects);
+    let context = this.setupCanvasContext();
+    this._prepareOverlay_auxFormat1Objects(context, rawjson.objects);
   }
 
   // Format 2


### PR DESCRIPTION
Separates state updates from effect of state update on the view.  I.e., the model from the view from the controller.  It is all still in the one class, but it is now more easy to understand.

Fixes certain aspects of autoplay and looping related to state.  

Also removes the canvas context as an instance variable and makes it a local variable.