### PR TITLE
index bug

### DIFF
--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -282,9 +282,8 @@ function ObjectOverlay(d, renderer) {
   this.label = d.label;
   this.labelUpper = this.label.toUpperCase();
   this.index = d.index;
-  if (typeof(this.index) == 'undefined') {
-    this.indexStr = '';
-  } else {
+  this.indexStr = '';
+  if (this.index != null) {
     this.indexStr = `${this.index}`;
   }
 


### PR DESCRIPTION
Fixes the bug where player51 shows undefined if no index is provided in the JSON. 
Now it doesn't show anything. 
Tested on images and videos.