### PR TITLE
Replace rollup-plugin-eslint-bundle with rollup-plugin-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-eslint-bundle": "^5.0.2",
+    "rollup-plugin-eslint": "^7.0.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-uglify": "^6.0.0"

--- a/rollup.cjs.js
+++ b/rollup.cjs.js
@@ -1,4 +1,4 @@
-import eslint from 'rollup-plugin-eslint-bundle';
+import {eslint} from 'rollup-plugin-eslint';
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';

--- a/rollup.iife.js
+++ b/rollup.iife.js
@@ -1,4 +1,4 @@
-import eslint from 'rollup-plugin-eslint-bundle';
+import {eslint} from 'rollup-plugin-eslint';
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';


### PR DESCRIPTION
This lints the source code, while rollup-plugin-eslint-bundle lints the _minified_ code, which I don't think was very useful (or intended) since that produced more than 4000 errors per build.

Note that this will require rerunning `npm install` before building.