### PR TITLE
object-fit contain -> cover to make sure the video controls do not ove…

### DIFF
--- a/src/css/player51.css
+++ b/src/css/player51.css
@@ -87,7 +87,7 @@
   margin: auto;
   height: 100%;
   width: 100%;
-  object-fit: fill;
+  object-fit: cover;
 }
 
 .p51-contained-canvas {


### PR DESCRIPTION
…rflow the image sequence

With `object-fit: contain`:
<img width="1205" alt="Screen Shot 2019-07-15 at 4 12 28 PM" src="https://user-images.githubusercontent.com/17344791/61245912-9fe43700-a71b-11e9-9638-4cc1c853c3ce.png">


With `object-fit: cover`:
<img width="1192" alt="Screen Shot 2019-07-15 at 4 17 11 PM" src="https://user-images.githubusercontent.com/17344791/61246075-09644580-a71c-11e9-9db8-3972802385aa.png">

This one con: if the image is too large for the container, then it will get cropped. Assuming dynamic resizing of container/image I think we'll be okay though.
