### PR TITLE
Add background to gallery nav icons to improve readability

### DIFF
--- a/src/css/player51.css
+++ b/src/css/player51.css
@@ -104,6 +104,7 @@
    width: auto;
    padding: 16px;
    margin-top: -24px;
+   background-color: rgba(0, 0, 0, 0.2);
    color: white;
    font-weight: bold;
    font-size: 25px;


### PR DESCRIPTION
The gallery navigation icons are white and had no background until they were hovered over, which made them impossible to see on a white background (even if they were always on top of the image, we can't count on user-uploaded images to always be dark). This should make them more readable.

Before:
![image](https://user-images.githubusercontent.com/3719547/61322574-fc0e9000-a7db-11e9-90f9-0534e311d50c.png)

After:
![image](https://user-images.githubusercontent.com/3719547/61322529-df725800-a7db-11e9-805e-76662b8c2177.png)


Darker image:
![image](https://user-images.githubusercontent.com/3719547/61324105-a0de9c80-a7df-11e9-870c-2adb4b73016d.png)
