### PR TITLE
Fix frame level attribute rendering

### DIFF
--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -274,6 +274,7 @@ Renderer.prototype.prepareOverlay = function(rawjson) {
   if (typeof(rawjson.frames) !== 'undefined') {
     const context = this.setupCanvasContext();
     const frameKeys = Object.keys(rawjson.frames);
+    /* eslint-disable-next-line no-unused-vars */
     for (const frameKeyI in frameKeys) {
       if (frameKeyI) {
         const frameKey = frameKeys[frameKeyI];
@@ -314,8 +315,8 @@ Renderer.prototype._prepareOverlay_auxAttributes = function(context,
   const o = new FrameAttributesOverlay(attributes, this);
   waitUntil(() => (typeof(this.canvasWidth) != 'undefined' &&
                    typeof(this.canvasHeight) != 'undefined'),
-    () => o.setup(context, this.canvasWidth, this.canvasHeight),
-    500);
+  () => o.setup(context, this.canvasWidth, this.canvasHeight),
+  500);
   if (frameKey) {
     this._prepareOverlay_auxCheckAdd(o, parseInt(frameKey));
   } else {

--- a/src/js/renderers/galleryrenderer.js
+++ b/src/js/renderers/galleryrenderer.js
@@ -223,6 +223,7 @@ GalleryRenderer.prototype.prepareOverlay = function(filename) {
 
   if (typeof(this._overlayData.images) !== 'undefined') {
     const frameKeys = Object.keys(this._overlayData.images);
+    /* eslint-disable-next-line no-unused-vars */
     for (const key in frameKeys) {
       if (this._overlayData.images[key].filename === filename) {
         entry = this._overlayData.images[key];
@@ -232,6 +233,7 @@ GalleryRenderer.prototype.prepareOverlay = function(filename) {
   } else if (typeof(this._overlayData.frames) !== 'undefined') {
     const frameKeys = Object.keys(this._overlayData.frames);
     const frameNumber = parseInt(filename.replace(/[^0-9]/g, ''));
+    /* eslint-disable-next-line no-unused-vars */
     for (const key in frameKeys) {
       if (parseInt(key) === frameNumber) {
         entry = this._overlayData.frames[key];
@@ -283,6 +285,7 @@ GalleryRenderer.prototype.clearState = function() {
   this._isReadyProcessFrames = false;
   URL.revokeObjectURL(this._currentImageURL);
   // Clear canvas
+  /* eslint-disable-next-line no-unused-vars */
   for (const key in this.frameOverlay) {
     if (key) {
       delete this.frameOverlay[key];


### PR DESCRIPTION
Fixes https://github.com/voxel51/console/issues/1636

Tested both job preview and shared job output, with output from an analytic that produces object labels (platform-demo) and output with frame-level attributes: [labels-with-frame-attrs.json.gz](https://github.com/voxel51/player51/files/3658858/labels-with-frame-attrs.json.gz) (by replacing the output of another job with this)

![image](https://user-images.githubusercontent.com/3719547/65706992-9a7b6500-e059-11e9-9e2e-523368d26e36.png)
