### PR TITLE
Fix double increment of frame counter

### DIFF
--- a/src/js/renderers/videorenderer.js
+++ b/src/js/renderers/videorenderer.js
@@ -501,7 +501,6 @@ VideoRenderer.prototype.customDraw = function(context) {
     context.fillText(hhmmss, x + pad, y + pad + fontheight - pad2, tw +
       8);
   }
-  this._frameNumber++;
 };
 
 


### PR DESCRIPTION
This was causing _frameNumber to be increment twice when the frame changed, which caused labels for alternating frames to be ignored (e.g. labels for frame 2 would be rendered on frames 2 and 3).

Fixes voxel51/console#1665