### PR TITLE
Fix FPS detection for slow-loading labels

### DIFF
--- a/src/js/renderers/videorenderer.js
+++ b/src/js/renderers/videorenderer.js
@@ -446,16 +446,16 @@ VideoRenderer.prototype.updateFromLoadingState = function() {
 
   if (this._overlayCanBePrepared) {
     this.prepareOverlay(this._overlayData);
-  }
 
-  if ((!isFinite(this.frameRate) || !isFinite(this.frameDuration)) &&
-      isFinite(this.eleVideo.duration)) {
-    // FPS wasn't provided, so guess it from the labels. If we don't have labels
-    // either, we can't determine anything, so fall back to FPS = 30.
-    const numFrames = Object.keys(this.frameOverlay).length ||
-        this.eleVideo.duration * 30;
-    this.frameRate = numFrames / this.eleVideo.duration;
-    this.frameDuration = 1 / this.frameRate;
+    if ((!isFinite(this.frameRate) || !isFinite(this.frameDuration)) &&
+        isFinite(this.eleVideo.duration)) {
+      // FPS wasn't provided, so guess it from the labels. If we don't have
+      // labels either, we can't determine anything, so fall back to FPS = 30.
+      const numFrames = Object.keys(this.frameOverlay).length ||
+          this.eleVideo.duration * 30;
+      this.frameRate = numFrames / this.eleVideo.duration;
+      this.frameDuration = 1 / this.frameRate;
+    }
   }
 };
 


### PR DESCRIPTION
84f51f67f58acb2ae0b39e58ddf3fb5c9739cb41 broke the case where labels do exist but are slow to load
(This is just moving the check into another check - [better diff](https://github.com/voxel51/player51/pull/77/files?w=1))