### PR TITLE
Intercept keyboard events handled by the renderer

### DIFF
--- a/src/js/renderers/videorenderer.js
+++ b/src/js/renderers/videorenderer.js
@@ -325,7 +325,11 @@ VideoRenderer.prototype.initPlayerControls = function() {
         self.eleVideo.currentTime = Math.min(
             self.eleVideo.duration,
             self.computeFrameTime() + self.frameDuration);
+      } else {
+        return;
       }
+      e.preventDefault();
+      e.stopPropagation();
       self.updateStateFromTimeChange();
     }
   });


### PR DESCRIPTION
For example, this keeps the right/left arrow keys from scrolling the page and navigating in the video at the same time