### PR TITLE
Non-uint8 support for frame masks

### DIFF
--- a/src/js/numpy.js
+++ b/src/js/numpy.js
@@ -17,6 +17,8 @@ const DATA_TYPES = {
   // we assume hosts are little-endian (like x86) so big-endian types are only
   // supported for 8-bit integers, where endianness doesn't matter
   '|b1': Uint8Array,
+  '<b1': Uint8Array,
+  '>b1': Uint8Array,
   '|u1': Uint8Array,
   '<u1': Uint8Array,
   '>u1': Uint8Array,


### PR DESCRIPTION
numpy arrays that weren't saved as `uint8` or `bool` would break. Tested with most types so far.

![image](https://user-images.githubusercontent.com/3719547/75291710-c0678a00-57f0-11ea-90ad-51a10729e04e.png)
