### PR TITLE
Change videos to use video src attribute instead of separate source tag

### DIFF
--- a/src/js/renderers/videorenderer.js
+++ b/src/js/renderers/videorenderer.js
@@ -78,13 +78,9 @@ VideoRenderer.prototype.initPlayer = function() {
   this.eleVideo = document.createElement('video');
   this.eleVideo.className = 'p51-contained-video';
   this.eleVideo.setAttribute('preload', 'metadata');
-  this.eleVideo.muted =
-    true; // this works whereas .setAttribute does not
+  this.eleVideo.setAttribute('src', this.media.src);
+  this.eleVideo.muted = true; // this works whereas .setAttribute does not
 
-  this.eleVideoSource = document.createElement('source');
-  this.eleVideoSource.setAttribute('src', this.media.src);
-  this.eleVideoSource.setAttribute('type', this.media.type);
-  this.eleVideo.appendChild(this.eleVideoSource);
   this.eleDivVideo.appendChild(this.eleVideo);
   this.parent.appendChild(this.eleDivVideo);
 
@@ -195,7 +191,7 @@ VideoRenderer.prototype.initPlayerControls = function() {
     self.updateStateFromTimeChange();
   });
 
-  this.eleVideoSource.addEventListener('error', function() {
+  this.eleVideo.addEventListener('error', function() {
     if (self.player._boolNotFound) {
       self.eleVideo.setAttribute('poster', self.player._notFoundPosterURL);
     }


### PR DESCRIPTION
This makes the "error" event fire when a video-related error occurs. It seems that some types of unsupported videos/encodings cause the browser to silently ignore a source, which is not what we want, but we only need one source per video anyway. (It doesn't appear possible to specify the mime type on the video tag, but that may only be used by browsers to skip unsupported types.)