### PR TITLE
Interim open source README.md note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a core component of the
 [FiftyOne](https://github.com/voxel51/fiftyone) App. Its exact future is to be
 determined, but it will continue to be actively developed. If one is
 determined to contribute to this project, please refer to the FiftyOne
-[CONTRIBUTING](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.rst)
+[CONTRIBUTING](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md)
 and make a best effort to follow them.
 
 # Player51


### PR DESCRIPTION
It is unclear to what the best way to manage `player51` as an open source project is at the moment, given our resources and focus on FiftyOne itself.

I propose this simple note for the time being until a proper course of action is determined.

A license should certainly be added to the project, in the meantime.

If we are happy with the open source documents that have been created for FiftyOne (templates, contributing, policies, etc.), I can try translating them over to this project over the weekend.