### PR TITLE
HTTPS Submodule(s)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Media-Fragments-URI"]
 	path = Media-Fragments-URI
-	url = git@github.com:tomayac/Media-Fragments-URI.git
+	url = https://github.com/tomayac/Media-Fragments-URI.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Media-Fragments-URI"]
 	path = Media-Fragments-URI
-	url = https://github.com/tomayac/Media-Fragments-URI.git
+	url = ../../tomayac/Media-Fragments-URI.git


### PR DESCRIPTION
I think it is best practice to use HTTPS submodules now that this project is public. This allows anyone to clone and install the player51, even if they do not have git ssh configured with GitHub.