### PR TITLE
Update to 2021 Copyright, adjust LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Copyright 2020, Voxel51, Inc. All rights reserved.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -174,3 +172,30 @@ Copyright 2020, Voxel51, Inc. All rights reserved.
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021, Voxel51, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -154,5 +154,5 @@ Then you can point your browser to `http://localhost:3000`.
 
 ## Copyright
 
-Copyright 2017-2020, Voxel51, Inc.<br>
+Copyright 2017-2021, Voxel51, Inc.<br>
 voxel51.com

--- a/src/css/player51.css
+++ b/src/css/player51.css
@@ -4,7 +4,7 @@
  * Part of this style sheet is for actual functionality while other parts are
  * for look and feel.  These are denoted in the comments.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  *
  * Jason Corso, jason@voxel51.com
  */

--- a/src/js/galleryviewer.js
+++ b/src/js/galleryviewer.js
@@ -6,7 +6,7 @@
  * @desc GalleryViewer is a javascript based image gallery that can render
  * available annotation and markup overlayed on top of the images.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Kevin Qi, kevin@voxel51.com
  */
 

--- a/src/js/imagesequence.js
+++ b/src/js/imagesequence.js
@@ -7,7 +7,7 @@
  * sequence of images and render annotations and markup overlayed on top while
  * playing through like a video.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Kevin Qi, kevin@voxel51.com
 */
 

--- a/src/js/imageviewer.js
+++ b/src/js/imageviewer.js
@@ -7,7 +7,7 @@
  * render available annotations and markup overlayed on top of the
  * image.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Kevin Qi, kevin@voxel51.com
  */
 

--- a/src/js/mediaplayer.js
+++ b/src/js/mediaplayer.js
@@ -6,7 +6,7 @@
  * @desc MediaPlayer.js is an abstract class that defines the features
  * child players should be able to support.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Kevin Qi, kevin@voxel51.com
  */
 

--- a/src/js/numpy.js
+++ b/src/js/numpy.js
@@ -2,7 +2,7 @@
  * @module numpy.js
  * @summary Utilities to parse serialized numpy arrays
  *
- * Copyright 2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Alan Stahl, alan@voxel51.com
  */
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -3,7 +3,7 @@
  * @summary Defines a series of helper classes that render the overlays on top
  * of either the video or image player.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Jason Corso, jason@voxel51.com
  * Brandon Paris, brandon@voxel51.com
  * Kevin Qi, kevin@voxel51.com

--- a/src/js/player51.js
+++ b/src/js/player51.js
@@ -62,7 +62,7 @@
  * Default: render as an image gallery.
  * SequenceFlag = true: render as a psuedo videoplayer.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Jason Corso, jason@voxel51.com
  * Brandon Paris, brandon@voxel51.com
  * Alan Stahl, alan@voxel51.com

--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -6,7 +6,7 @@
  * @desc Renderer is an abstract class that defines the features child
  * renderers should be able to support.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Alan Stahl, alan@voxel51.com
  */
 

--- a/src/js/renderers/galleryrenderer.js
+++ b/src/js/renderers/galleryrenderer.js
@@ -6,7 +6,7 @@
  * @desc GalleryRenderer is a class that controls the creation and viewing of
  * galleryviewer.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Kevin Qi, kevin@voxel51.com
  */
 

--- a/src/js/renderers/imagerenderer.js
+++ b/src/js/renderers/imagerenderer.js
@@ -6,7 +6,7 @@
  * @desc ImageRenderer is a class that controls the creation and viewing of
  * imageviewer.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Kevin Qi, kevin@voxel51.com
  */
 

--- a/src/js/renderers/imagesequencerenderer.js
+++ b/src/js/renderers/imagesequencerenderer.js
@@ -5,7 +5,7 @@
  * @desc ImageSequenceRenderer is a class that controls the creation and
  * viewing of imagesequence.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Alan Stahl, alan@voxel51.com
  */
 

--- a/src/js/renderers/videorenderer.js
+++ b/src/js/renderers/videorenderer.js
@@ -6,7 +6,7 @@
  * @desc VideoRenderer is a class that controls the creation and viewing of
  * videoplayer.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Alan Stahl, alan@voxel51.com
  */
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -2,7 +2,7 @@
  * @module util.js
  * @summary Utilities for player51
  *
- * Copyright 2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Alan Stahl, alan@voxel51.com
  */
 

--- a/src/js/videoplayer.js
+++ b/src/js/videoplayer.js
@@ -7,7 +7,7 @@
  * render available annotations and markup overlayed on top of the
  * video.
  *
- * Copyright 2017-2020, Voxel51, Inc.
+ * Copyright 2017-2021, Voxel51, Inc.
  * Jason Corso, jason@voxel51.com
  * Brandon Paris, brandon@voxel51.com
  * Kevin Qi, kevin@voxel51.com

--- a/test/download_data.py
+++ b/test/download_data.py
@@ -5,7 +5,7 @@ Downloads example data from Google Drive.
 Usage:
     python download_data.py
 
-Copyright 2017-2020, Voxel51, LLC
+Copyright 2017-2021, Voxel51, LLC
 voxel51.com
 
 Brian Moore, brian@voxel51.com


### PR DESCRIPTION
Updates copyright lines to 2021 and adjusts the LICENSE, as done in https://github.com/voxel51/fiftyone/pull/788, so GitHub can recognize the license.