### PR TITLE
Deprecate project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DEPRECATED
 
-This project has been deprecated by [Looker](https://github.com/voxel51/fiftyone/tree/develop/app)
+This project has been deprecated by [Looker](https://github.com/voxel51/fiftyone/tree/develop/app),
+the media visualizer of [FiftyOne](https://github.com/voxel51/fiftyone).
 
 # Player51
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-# NOTE
+# DEPRECATED
 
-This project is a core component of the
-[FiftyOne](https://github.com/voxel51/fiftyone) App. Its exact future is to be
-determined, but it will continue to be actively developed. If one is
-determined to contribute to this project, please refer to the FiftyOne
-[CONTRIBUTING](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md)
-and make a best effort to follow them.
+This project has been deprecated by [Looker](https://github.com/voxel51/fiftyone/tree/develop/app)
 
 # Player51
 


### PR DESCRIPTION
Updates the README to indicate the projects deprecation/archival

I'm recommending that we explicitly archive the project, as well. See [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/archiving-a-github-repository/archiving-repositories)